### PR TITLE
Implement atomic password update and first login clear

### DIFF
--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/StaffService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/StaffService.java
@@ -17,10 +17,11 @@ public interface StaffService extends GenericService<Staff> {
 
     boolean canStaffAccessSystem(Staff staff);
 
-    /**
-     * Retrieves a Staff entity using the associated User account.
-     * @param user The user account to search with.
-     * @return The matching Staff member, or null if not found.
-     */
     Staff getStaffByUser(User user);
+
+    /**
+     * Atomically updates a user's password, hashes it, and clears the first login flag on the associated staff profile.
+     * @return The updated Staff entity.
+     */
+    Staff updatePasswordAndClearFirstLogin(Staff staff, String newPassword) throws ValidationFailedException, OperationFailedException;
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/utils/Validate.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/utils/Validate.java
@@ -110,6 +110,30 @@ public abstract class Validate {
 	}
 
 	/**
+	 * Assert that the given String contains valid text content; that is, it
+	 * must not be {@code null} and must contain at least one non-whitespace
+	 * character.
+	 *
+	 * <pre class="code">
+	 * Assert.notBlank(name, "'name' must not be empty");
+	 * </pre>
+	 *
+	 * @param text
+	 *            the String to check
+	 * @param message
+	 *            the exception message to use if the assertion fails
+	 * @param args
+	 *            optional arguments for the message
+	 * @throws ValidationFailedException
+	 *             if the text does not contain valid text content
+	 */
+	public static void notBlank(String text, String message, Object... args) throws ValidationFailedException {
+		if (!StringUtils.isNotBlank(text)) {
+			throw new ValidationFailedException(format(message, args));
+		}
+	}
+
+	/**
 	 * Assert that the given String is not empty; that is, it must not be
 	 * {@code null} and not the empty String.
 	 * 

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/auth/ChangePasswordView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/auth/ChangePasswordView.java
@@ -11,6 +11,8 @@ import org.pahappa.systems.kpiTracker.security.UiUtils;
 import org.sers.webutils.model.exception.OperationFailedException;
 import org.sers.webutils.model.exception.ValidationFailedException;
 import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.security.service.impl.CustomSessionProvider;
+import org.sers.webutils.server.core.security.util.CustomSecurityUtil;
 import org.sers.webutils.server.core.service.UserService;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
 import org.sers.webutils.server.shared.SharedAppData;
@@ -48,28 +50,24 @@ public class ChangePasswordView implements Serializable {
                 throw new ValidationFailedException("Passwords do not match or are blank.");
             }
 
-            User loggedInUser = SharedAppData.getLoggedInUser();
-            if (loggedInUser == null) {
+            User sessionUser = SharedAppData.getLoggedInUser();
+            if (sessionUser == null) {
                 throw new ValidationFailedException("Your session has expired. Please log in again.");
             }
 
-            // Find the staff record associated with the logged-in user
-            Staff staff = staffService.getStaffByUser(loggedInUser);
+            // Fetch the staff member associated with the current session user
+            Staff staff = staffService.getStaffByUser(sessionUser);
             if (staff == null) {
                 throw new OperationFailedException("Could not find an associated staff profile.");
             }
 
-            // 1. Set the new password on the User object
-            loggedInUser.setClearTextPassword(this.newPassword);
+            // Call the new atomic service method to handle the entire business transaction
+            Staff updatedStaff = staffService.updatePasswordAndClearFirstLogin(staff, this.newPassword);
 
-            // 2. Clear the firstLogin flag on the Staff object
-            staff.setFirstLogin(false);
+            // Best Practice: Update the user object in the current session with the newly persisted data.
+            // The updatedStaff object contains the fully updated User account.
+            ApplicationContextProvider.getBean(CustomSessionProvider.class).setLoggedInUser(updatedStaff.getUserAccount());
 
-            // 3. Save both entities
-            userService.saveUser(loggedInUser);
-            staffService.saveStaff(staff);
-
-            // 4. Show success and redirect
             UiUtils.showMessageBox("Password successfully updated. Redirecting to dashboard...", "Success");
             ExternalContext ec = FacesContext.getCurrentInstance().getExternalContext();
             ec.redirect(ec.getRequestContextPath() + HyperLinks.DASHBOARD);

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/staff/StaffFormDialog.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/staff/StaffFormDialog.java
@@ -2,6 +2,7 @@ package org.pahappa.systems.kpiTracker.views.staff;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 import org.pahappa.systems.kpiTracker.core.services.StaffService;
 import org.pahappa.systems.kpiTracker.models.constants.StaffStatus;
 import org.pahappa.systems.kpiTracker.models.staff.Staff;
@@ -61,10 +62,9 @@ public class StaffFormDialog extends DialogForm<Staff> {
     @Override
     public void persist() throws Exception {
         if (edit) {
-            // Update existing staff
             userService.saveUser(super.getModel().getUserAccount());
+            staffService.saveStaff(super.getModel());
         } else {
-            // Create new staff with a user account
             createNewStaff();
         }
     }
@@ -73,8 +73,8 @@ public class StaffFormDialog extends DialogForm<Staff> {
      * Creates a new staff record and associated user account.
      */
     private void createNewStaff() throws Exception {
-        if (model.getUserAccount() == null) {
-            throw new ValidationFailedException("User account is required for staff creation.");
+        if (model.getUserAccount() == null || StringUtils.isBlank(model.getUserAccount().getEmailAddress())) {
+            throw new ValidationFailedException("User email is required for staff creation.");
         }
 
         User user = model.getUserAccount();
@@ -82,8 +82,9 @@ public class StaffFormDialog extends DialogForm<Staff> {
 
         if (this.selectedRole != null) {
             user.setRoles(new HashSet<>(Collections.singletonList(this.selectedRole)));
+        } else {
+            throw new ValidationFailedException("A role must be selected for the new staff.");
         }
-
 
         this.staffService.createNewStaff(super.model);
     }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/staff/StaffView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/staff/StaffView.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.pahappa.systems.kpiTracker.core.services.StaffService;
+import org.pahappa.systems.kpiTracker.models.constants.StaffStatus;
 import org.pahappa.systems.kpiTracker.models.staff.Staff;
 import org.pahappa.systems.kpiTracker.security.HyperLinks;
 import org.pahappa.systems.kpiTracker.security.UiUtils;
@@ -50,6 +51,7 @@ public class StaffView extends PaginatedTableView<Staff, StaffService, StaffServ
     private long totalStaff;
     private long maleStaff;
     private long femaleStaff;
+    private long activeStaff;
 
     @PostConstruct
     public void init() {

--- a/frontend/kpi-tracker-web/src/main/webapp/ExternalViews/changePassword.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/ExternalViews/changePassword.xhtml
@@ -316,7 +316,7 @@
                                  action="#{changePasswordView.saveNewPassword}"
                                  styleClass="login-button"
                                  validateClient="true"
-                                 update="messages"
+                                 update="@form"
                                  icon="pi pi-save" />
             </h:form>
         </div>


### PR DESCRIPTION
Added a new service method to atomically update a user's password and clear the firstLogin flag on the associated staff profile. Refactored the change password workflow to use this method, ensuring transactional integrity. Improved staff creation validation and error handling, and made minor UI updates for better feedback.