### PR TITLE
Add goal and goal period management features

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/staff/Staff.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/staff/Staff.java
@@ -114,6 +114,22 @@ public class Staff extends BaseEntity {
         this.firstLogin = firstLogin;
     }
 
+    @Transient
+    public String getFullName() {
+        StringBuilder fullName = new StringBuilder();
+        if (firstName != null && !firstName.isEmpty()) {
+            fullName.append(firstName);
+        }
+        if (lastName != null && !lastName.isEmpty()) {
+            if (fullName.length() > 0) {
+                fullName.append(" ");
+            }
+            fullName.append(lastName);
+        }
+        return fullName.toString();
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -31,4 +31,12 @@ public class HyperLinks {
     public static final String TEAM_FORM_DIALOG = "/pages/team/TeamForm.xhtml";
     public static final String TEAM_MEMBER_VIEW = "/pages/team/TeamMemberView.xhtml?faces-redirect=true";
     public static final String TEAM_MEMBER_FORM_DIALOG = "/pages/team/TeamMemberForm.xhtml";
+
+
+    public static final String GOAL_PERIOD_VIEW = "/pages/goals/goalPeriod/GoalPeriodView.xhtml?faces-redirect=true";
+    public static final String GOAL_PERIOD_FORM = "/pages/goals/goalPeriod/GoalPeriodForm.xhtml?faces-redirect=true";
+    public static final String GOAL_LEVEL_VIEW = "/pages/goals/goalLevel/GoalLevelView.xhtml?faces-redirect=true";
+
+    public static final String GOAL_FORM_DIALOG="/pages/goal/GoalFormDialog.xhtml?faces-redirect=true";
+    public static final String GOAL_VIEW = "/pages/goal/GoalView.xhtml?faces-redirect=true";
 }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goal/GoalFormDialog.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goal/GoalFormDialog.java
@@ -1,0 +1,251 @@
+package org.pahappa.systems.kpiTracker.views.goal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.constants.GoalLevel;
+import org.pahappa.systems.kpiTracker.core.services.DepartmentService;
+import org.pahappa.systems.kpiTracker.core.services.GoalPeriodService;
+import org.pahappa.systems.kpiTracker.core.services.GoalService;
+import org.pahappa.systems.kpiTracker.core.services.StaffService;
+import org.pahappa.systems.kpiTracker.models.department.Department;
+import org.pahappa.systems.kpiTracker.models.goal.Goal;
+import org.pahappa.systems.kpiTracker.models.goal.GoalPeriod;
+import org.pahappa.systems.kpiTracker.models.staff.Staff;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.service.UserService;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+import org.sers.webutils.server.shared.SharedAppData;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@ManagedBean(name = "goalFormDialog")
+@SessionScoped
+@ViewPath(path = HyperLinks.GOAL_FORM_DIALOG)
+public class GoalFormDialog extends DialogForm<Goal> {
+    private GoalService goalService;
+    private StaffService staffService;
+    private DepartmentService departmentService;
+    private GoalPeriodService goalPeriodService;
+
+    private List<User> availableUsers;
+    private List<Staff> availableStaff;
+    private List<GoalPeriod> goalPeriods;
+    private GoalLevel selectedGoalLevel;
+    private List<GoalLevel> goalLevels;
+    private List<Goal> availableParentGoals;
+    private List<Department> availableDepartments;
+
+    private boolean edit;
+
+    /**
+     * FIX 1: Added a public, no-argument constructor.
+     * JSF requires this to instantiate the bean. Its absence was the
+     * root cause of the "JSF1090: Navigation case not resolved" error.
+     */
+    public GoalFormDialog() {
+        super(HyperLinks.GOAL_FORM_DIALOG, 600, 650);
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            this.goalService = ApplicationContextProvider.getBean(GoalService.class);
+            this.staffService = ApplicationContextProvider.getBean(StaffService.class);
+            this.goalPeriodService = ApplicationContextProvider.getBean(GoalPeriodService.class);
+            this.departmentService = ApplicationContextProvider.getBean(DepartmentService.class);
+            this.goalPeriods = goalPeriodService.getAllInstances();
+            this.availableStaff = this.staffService.getAllInstances();
+            this.goalLevels = Arrays.asList(GoalLevel.values()); // Initialize goalLevels
+            this.availableParentGoals = Collections.emptyList();
+            this.availableDepartments = departmentService.getAllInstances();
+        } catch (Exception e) {
+            // Log the error and initialize with empty collections
+            System.err.println("Error initializing GoalFormDialog: " + e.getMessage());
+            e.printStackTrace();
+            this.goalPeriods = Collections.emptyList();
+            this.availableUsers = Collections.emptyList();
+            this.availableStaff = Collections.emptyList();
+            this.goalLevels = Arrays.asList(GoalLevel.values());
+            this.availableParentGoals = Collections.emptyList();
+            this.availableDepartments = Collections.emptyList();
+        }
+    }
+
+    @Override
+    public void persist() throws Exception {
+        try {
+            // Set default values for required fields that might not be set by the form
+            if (super.model.getEvaluationTarget() == 0.0) {
+                super.model.setEvaluationTarget(100.0); // Default evaluation target
+            }
+
+            // // Set default owner for new goals (logged-in user's staff record)
+            Staff currentStaff = getLoggedInUser();
+            System.out.println("Current staff: " + (currentStaff != null ? currentStaff.getFullName() : "null"));
+
+            if (currentStaff != null) {
+                super.model.setOwner(currentStaff);
+                System.out.println("Owner set to: " + super.model.getOwner().getFullName());
+            }
+
+            // Validate required fields before saving
+            if (super.model.getGoalLevel() == null) {
+                throw new Exception("Goal level is required");
+            }
+            if (super.model.getGoalName() == null || super.model.getGoalName().trim().isEmpty()) {
+                throw new Exception("Goal name is required");
+            }
+            if (super.model.getDescription() == null || super.model.getDescription().trim().isEmpty()) {
+                throw new Exception("Goal description is required");
+            }
+            if (super.model.getGoalPeriod() == null) {
+                throw new Exception("Goal period is required");
+            }
+            if (super.model.getOwner() == null) {
+                throw new Exception("Goal owner is required");
+            }
+            System.out.println("Saving goal with owner: " + super.model.getOwner().getFullName());
+
+            // assign organisational goals weight to 100
+            if (super.model.getGoalLevel() != null && super.model.getGoalLevel() == GoalLevel.ORGANISATION) {
+                super.model.setWeight(100);
+            }
+
+            this.goalService.saveInstance(super.model);
+
+            System.out.println("Goal saved successfully!");
+
+        } catch (Exception e) {
+            System.err.println("Error in persist method: " + e.getMessage());
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new Goal();
+        setEdit(false);
+        this.selectedGoalLevel = null;
+        this.availableParentGoals = Collections.emptyList();
+        super.model.setDepartment(null);
+        super.model.setWeight(0.0);
+        super.model.setDescription(null);
+    }
+
+    @Override
+    public void setFormProperties() {
+        super.setFormProperties();
+        try {
+            this.availableStaff = this.staffService.getAllInstances();
+            this.goalPeriods = goalPeriodService.getAllInstances();
+        } catch (Exception e) {
+            System.err.println("Error loading form properties: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        // Set edit flag based on whether model has an ID
+        if (super.model != null && super.model.getId() != null) {
+            setEdit(true);
+        } else {
+            setEdit(false);
+            // Set default values for new goals
+            Staff currentStaff = getLoggedInUser();
+            if (currentStaff != null) {
+                super.model.setOwner(currentStaff);
+            }
+            // Set default evaluation target
+            super.model.setEvaluationTarget(100.0);
+            // Set default progress
+            super.model.setProgress(0.0);
+        }
+    }
+
+    public Staff getLoggedInUser() {
+        if (staffService != null) {
+            User loggedInUser = SharedAppData.getLoggedInUser();
+            System.out.println("Logged in user from SharedAppData: "
+                    + (loggedInUser != null ? loggedInUser.getFirstName() + " " + loggedInUser.getLastName() : "null"));
+            if (loggedInUser != null) {
+                Staff staff = staffService.getStaffByUser(loggedInUser);
+                System.out.println("Staff found for user: " + (staff != null ? staff.getFullName() : "null"));
+                return staff;
+            }
+        }
+        System.out.println("StaffService is null or no logged in user");
+        return null;
+    }
+
+    public void onGoalLevelChange() {
+        System.out.println("Goal level changed to: " +
+                (super.model.getGoalLevel() != null ? super.model.getGoalLevel().getDisplayName() : "null"));
+
+        // Clear dependent fields when goal level changes
+        super.model.setParentGoal(null);
+        super.model.setDepartment(null);
+        super.model.setWeight(0.0);
+        super.model.setOwner(null);
+
+        if (super.model.getGoalLevel() != null) {
+            // Load available parent goals for non-organisation levels
+            if (super.model.getGoalLevel() != GoalLevel.ORGANISATION) {
+                this.availableParentGoals = goalService.getPotentialParentGoals(super.model.getGoalLevel());
+                System.out.println("Available parent goals: " + this.availableParentGoals.size());
+            } else {
+                this.availableParentGoals = Collections.emptyList();
+            }
+
+            // Set default owner for individual goals
+            if (super.model.getGoalLevel() == GoalLevel.INDIVIDUAL) {
+                Staff currentStaff = getLoggedInUser();
+                if (currentStaff != null) {
+                    super.model.setOwner(currentStaff);
+                    System.out.println("Set default owner: " + currentStaff.getFullName());
+                }
+            }
+        } else {
+            this.availableParentGoals = Collections.emptyList();
+        }
+    }
+
+    public void onParentGoalChange() {
+        if ((super.model.getGoalLevel() == GoalLevel.TEAM || super.model.getGoalLevel() == GoalLevel.INDIVIDUAL)
+                && super.model.getParentGoal() != null) {
+            super.model.setDepartment(super.model.getParentGoal().getDepartment());
+        } else {
+            super.model.setDepartment(null);
+        }
+    }
+
+    public boolean isDepartmentApplicable() {
+        return super.model.getGoalLevel() != null && super.model.getGoalLevel() != GoalLevel.ORGANISATION;
+    }
+
+    public boolean isDepartmentEditable() {
+        return super.model.getGoalLevel() != null && super.model.getGoalLevel() != GoalLevel.TEAM
+                && super.model.getGoalLevel() != GoalLevel.INDIVIDUAL;
+    }
+
+    public boolean isParentApplicable() {
+        return super.model.getGoalLevel() != null && super.model.getGoalLevel() != GoalLevel.ORGANISATION;
+    }
+
+    public boolean isWeightApplicable() {
+        return isParentApplicable();
+    }
+
+    public boolean isOwnerApplicable() {
+        return super.model.getGoalLevel() != null && super.model.getGoalLevel() == GoalLevel.INDIVIDUAL;
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goal/GoalView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goal/GoalView.java
@@ -1,0 +1,157 @@
+package org.pahappa.systems.kpiTracker.views.goal;
+
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.constants.GoalLevel;
+import org.pahappa.systems.kpiTracker.constants.GoalStatus;
+import org.pahappa.systems.kpiTracker.core.services.GoalService;
+import org.pahappa.systems.kpiTracker.core.services.StaffService;
+import org.pahappa.systems.kpiTracker.models.goal.Goal;
+import org.pahappa.systems.kpiTracker.models.staff.Staff;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.views.dialogs.MessageComposer;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+import org.sers.webutils.server.shared.SharedAppData;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@ViewPath(path = HyperLinks.GOAL_VIEW)
+@ManagedBean(name = "goalView")
+@ViewScoped
+@Getter // Lombok to generate all getters
+@Setter // Lombok to generate all setters
+public class GoalView implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private GoalService goalService;
+    private StaffService staffService;
+    private int activeTabIndex;
+
+    // --- NEW PROPERTIES TO HOLD DATA FOR THE VIEW ---
+    private List<Goal> myGoals;
+    private List<Goal> organisationGoals;
+    private List<Goal> departmentGoals;
+    private List<Goal> teamGoals;
+    private DashboardMetrics dashboardMetrics;
+
+    @PostConstruct
+    public void init() {
+        this.goalService = ApplicationContextProvider.getBean(GoalService.class);
+        this.staffService = ApplicationContextProvider.getBean(StaffService.class);
+        this.dashboardMetrics = new DashboardMetrics(); // Initialize the metrics object
+        reloadFilterReset();
+    }
+
+    public void reloadFilterReset() {
+        reloadGoals();
+        loadDashboardMetrics();
+        this.activeTabIndex = 0; // Set the active tab to the first one
+    }
+
+    private void reloadGoals() {
+        // Assign fetched lists to the class properties
+        this.myGoals = fetchMyGoals();
+        this.organisationGoals = fetchGoalsByLevel(GoalLevel.ORGANISATION);
+        this.departmentGoals = fetchGoalsByLevel(GoalLevel.DEPARTMENT);
+        this.teamGoals = fetchGoalsByLevel(GoalLevel.TEAM);
+    }
+
+    private List<Goal> fetchMyGoals() {
+        User loggedInUser = SharedAppData.getLoggedInUser();
+        System.out.println("Logged-in User: "
+                + (loggedInUser != null ? loggedInUser.getFirstName() + " " + loggedInUser.getLastName() : "null"));
+        if (loggedInUser == null) {
+            MessageComposer.error("Error", "No logged-in user found. Please log in again.");
+            return Collections.emptyList();
+        }
+
+        // Convert User to Staff object
+        Staff staff = staffService.getStaffByUser(loggedInUser);
+        if (staff == null) {
+            MessageComposer.error("Error",
+                    "No staff record found for the logged-in user. Please contact administrator.");
+            return Collections.emptyList();
+        }
+
+        // Use the new method with JOIN FETCH to avoid LazyInitializationException
+        List<Goal> goals = goalService.getGoalsByOwner(staff, GoalLevel.INDIVIDUAL);
+        System.out.println("My Goals fetched: " + goals.size());
+        return goals;
+    }
+
+    private List<Goal> fetchGoalsByLevel(GoalLevel level) {
+        // Use the new method with JOIN FETCH to avoid LazyInitializationException
+        List<Goal> goals = goalService.getGoalsByLevel(level);
+        System.out.println(level.getDisplayName() + " Goals fetched: " + goals.size());
+        return goals;
+    }
+
+    private void loadDashboardMetrics() {
+        Search allSearch = new Search(Goal.class);
+        allSearch.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+        this.dashboardMetrics.setTotalGoals(goalService.countInstances(allSearch));
+
+        // --- CORRECTED LOGIC ---
+        // Use 'goalStatus' and 'goalPeriod.endDate' which are mapped to the database.
+
+        // Active goals are those that are not completed and whose end date is in the
+        // future.
+        Search activeSearch = new Search(Goal.class);
+        activeSearch.addFilterNotEqual("goalStatus", GoalStatus.COMPLETED); // Not completed yet
+        activeSearch.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+        activeSearch.addFilterOr(
+                Filter.isNull("goalPeriod.endDate"), // No end date is considered active
+                Filter.greaterThan("goalPeriod.endDate", new Date()) // End date is in the future
+        );
+        this.dashboardMetrics.setActiveGoals(goalService.countInstances(activeSearch));
+
+        // Completed goals are straightforward.
+        Search completedSearch = new Search(Goal.class);
+        completedSearch.addFilterEqual("goalStatus", GoalStatus.COMPLETED);
+        completedSearch.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+        this.dashboardMetrics.setCompletedGoals(goalService.countInstances(completedSearch));
+
+        // Overdue goals are not completed and their end date is in the past.
+        Search overdueSearch = new Search(Goal.class);
+        overdueSearch.addFilterNotEqual("goalStatus", GoalStatus.COMPLETED); // Not completed yet
+        overdueSearch.addFilterNotNull("goalPeriod.endDate"); // Must have an end date
+        overdueSearch.addFilterLessThan("goalPeriod.endDate", new Date()); // End date is in the past
+        overdueSearch.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+        this.dashboardMetrics.setOverdueGoals(goalService.countInstances(overdueSearch));
+    }
+
+    public void deleteSelectedGoal(Goal goalToDelete) {
+        try {
+            if (goalToDelete != null) {
+                goalService.deleteInstance(goalToDelete);
+                MessageComposer.info("Success", "Goal '" + goalToDelete.getGoalName() + "' has been deleted.");
+                reloadGoals(); // Just reload goals, no need to reload everything
+            } else {
+                MessageComposer.error("Error", "System Error: The record to delete was not provided.");
+            }
+        } catch (Exception e) {
+            MessageComposer.error("Deletion Failed", e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    // Inner class for DashboardMetrics
+    @Setter
+    @Getter
+    public static class DashboardMetrics {
+        private int totalGoals;
+        private int activeGoals;
+        private int completedGoals;
+        private int overdueGoals;
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goalPeriod/GoalPeriodForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goalPeriod/GoalPeriodForm.java
@@ -1,0 +1,103 @@
+package org.pahappa.systems.kpiTracker.views.goalPeriod;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.GoalPeriodService;
+import org.pahappa.systems.kpiTracker.models.goal.GoalPeriod;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.io.Serializable;
+import java.util.Date;
+
+@Setter
+@Getter
+@ManagedBean(name = "goalPeriodForm")
+@SessionScoped
+@ViewPath(path = HyperLinks.GOAL_PERIOD_FORM)
+public class GoalPeriodForm extends DialogForm<GoalPeriod> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private boolean edit;
+
+    private transient GoalPeriodService goalPeriodService;
+
+    public GoalPeriodForm() {
+        super(HyperLinks.GOAL_PERIOD_FORM, 700, 450);
+    }
+
+    @PostConstruct
+    public void init() {
+        this.goalPeriodService = ApplicationContextProvider.getBean(GoalPeriodService.class);
+        super.model = new GoalPeriod();
+        // Initialize dates as null to keep datepicker empty
+        super.model.setStartDate(null);
+        super.model.setEndDate(null);
+        System.out.println("Init - End Date: " + (super.model.getEndDate() != null ? super.model.getEndDate().toString() : "null"));
+    }
+
+    @Override
+    public void persist() throws Exception {
+        // Validate the sum of MBO and Org Fit weights as doubles
+        double mboWeight = super.model.getBusinessGoalContribution(); // Defaults to 0.0 if not set
+        double orgFitWeight = super.model.getOrganisationalFitScore(); // Defaults to 0.0 if not set
+        double totalWeight = mboWeight + orgFitWeight;
+
+        // Use a small epsilon to handle floating-point precision
+        final double EPSILON = 0.001;
+        if (Math.abs(totalWeight - 100.0) > EPSILON && totalWeight > 100.0) {
+            UiUtils.ComposeFailure("Validation Error",
+                    String.format("The sum of MBO Weight and Org Fit Weight must not exceed 100.0%%. Current sum: %.2f%%. Please correct the values.", totalWeight));
+            throw new ValidationFailedException("The sum of MBO Weight and Org Fit Weight must not exceed 100.0%.");
+        }
+
+        try {
+            this.goalPeriodService.saveInstance(super.model);
+
+        } catch (ValidationFailedException e) {
+            UiUtils.ComposeFailure("Validation Error", e.getLocalizedMessage());
+        } catch (Exception e) {
+            UiUtils.ComposeFailure("Action Failed", e.getMessage());
+        }
+    }
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new GoalPeriod();
+        // Keep dates null to ensure empty datepicker
+        super.model.setStartDate(null);
+        super.model.setEndDate(null);
+        System.out.println("Reset - End Date: " + (super.model.getEndDate() != null ? super.model.getEndDate().toString() : "null"));
+    }
+
+    @Override
+    public void setFormProperties() {
+        super.setFormProperties();
+        if (super.model != null && super.model.getId() != null) {
+            setEdit(true);
+        } else {
+            if (super.model == null) {
+                super.model = new GoalPeriod();
+            }
+            setEdit(false);
+            // Ensure dates are null for new forms
+            super.model.setStartDate(null);
+            super.model.setEndDate(null);
+        }
+    }
+
+    // Debugging method to check selected date
+    public void printDate() {
+        String message = "End Date: " + (super.model.getEndDate() != null ? super.model.getEndDate().toString() : "null");
+        System.out.println(message);
+
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goalPeriod/GoalPeriodView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goalPeriod/GoalPeriodView.java
@@ -1,0 +1,147 @@
+package org.pahappa.systems.kpiTracker.views.goalPeriod;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.GoalPeriodService;
+import org.pahappa.systems.kpiTracker.models.goal.GoalPeriod;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.views.dialogs.MessageComposer;
+import org.primefaces.model.FilterMeta;
+import org.primefaces.model.SortMeta;
+import org.sers.webutils.client.views.presenters.PaginatedTableView;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.utils.SearchField;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@SessionScoped
+@Getter
+@Setter
+@ViewPath(path = HyperLinks.GOAL_PERIOD_VIEW)
+@ManagedBean(name = "goalPeriodView")
+public class GoalPeriodView extends PaginatedTableView<GoalPeriod, GoalPeriodService, GoalPeriodService> {
+
+    private static final long serialVersionUID = 1L;
+    public GoalPeriodService goalPeriodService;
+    private GoalPeriod selectedGoalPeriod;
+    private List<SearchField> searchFields, selectedSearchFields;
+
+    // Search functionality
+    private String searchTerm = "";
+
+    @PostConstruct
+    public void init() {
+        try {
+            goalPeriodService = ApplicationContextProvider.getBean(GoalPeriodService.class);
+            this.reloadFilterReset();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @Override
+    public void reloadFromDB(int i, int i1, Map<String, Object> map) throws Exception {
+        super.setDataModels(goalPeriodService
+                .getInstances(new Search().addFilterEqual("recordStatus", RecordStatus.ACTIVE), i, i1));
+    }
+
+    // @Override
+    // public List<GoalPeriod> load(int first, int pageSize, Map<String, SortMeta>
+    // sortBy,
+    // Map<String, FilterMeta> filterBy) {
+    // return getDataModels();
+    // }
+
+    @Override
+    public void reloadFilterReset() {
+        super.setTotalRecords(goalPeriodService.countInstances(new Search()));
+        try {
+            super.reloadFilterReset();
+        } catch (Exception e) {
+            UiUtils.ComposeFailure("Error", e.getLocalizedMessage());
+        }
+
+    }
+
+    /**
+     * Deletes the specific GoalPeriod passed from the UI.
+     *
+     * @param periodToDelete The record selected by the user in the data table.
+     */
+    public void deleteSelectedGoalsPeriod(GoalPeriod periodToDelete) {
+        try {
+            // We check the parameter directly. It's much safer.
+            if (periodToDelete != null) {
+                goalPeriodService.deleteInstance(periodToDelete);
+                MessageComposer.info("Success",
+                        "Period '" + periodToDelete.getPeriodName() + "' has been deleted.");
+                // The table refresh will be handled by the 'update' attribute on the button.
+            } else {
+                // This is a safeguard. It should not happen if the UI is correct.
+                MessageComposer.error("Error", "System Error: The record to delete was not provided.");
+            }
+        } catch (Exception e) {
+            MessageComposer.error("Deletion Failed", e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public List<ExcelReport> getExcelReportModels() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getFileName() {
+        return "";
+    }
+
+    @Override
+    public List<GoalPeriod> load(int i, int i1, Map<String, SortMeta> map, Map<String, FilterMeta> map1) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Search for goal periods based on the search term
+     */
+    public void search() {
+        try {
+            if (searchTerm == null || searchTerm.trim().isEmpty()) {
+                // If search term is empty, reload all data
+                this.reloadFilterReset();
+            } else {
+                // Create search criteria
+                Search search = new Search();
+                search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+                search.addFilterILike("periodName", "%" + searchTerm.trim() + "%");
+
+                // Get filtered results
+                List<GoalPeriod> filteredResults = goalPeriodService.getInstances(search, 0, Integer.MAX_VALUE);
+                super.setDataModels(filteredResults);
+                super.setTotalRecords(filteredResults.size());
+            }
+        } catch (Exception e) {
+            UiUtils.ComposeFailure("Search Error", "Error searching periods: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Clear the search and reload all data
+     */
+    public void clearSearch() {
+        searchTerm = "";
+        this.reloadFilterReset();
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
+++ b/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
@@ -48,6 +48,7 @@
 		<mapping class="org.pahappa.systems.kpiTracker.models.department.Department"/>
 		<mapping class="org.pahappa.systems.kpiTracker.models.team.Team"/>
 		<mapping class="org.pahappa.systems.kpiTracker.models.team.TeamMember"/>
-		
+		<mapping class="org.pahappa.systems.kpiTracker.models.goal.Goal"/>
+		<mapping class="org.pahappa.systems.kpiTracker.models.goal.GoalPeriod"/>
 	</session-factory>
 </hibernate-configuration>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
@@ -31,6 +31,11 @@
                 <pc:menu widgetVar="CaliforniaMenuWidget">
                     <p:menuitem id="dashboard" value="Dashboard" icon="pi pi-fw pi-home"
                         outcome="/pages/dashboard/Dashboard" />
+                    <p:submenu id="goals" label="Goals and Objectives" icon="pi pi-fw pi-megaphone">
+
+                        <p:menuitem id="newgoals" value="Goals"  icon="pi pi-fw pi-sitemap"
+                                    outcome="/pages/goal/GoalView" />
+                    </p:submenu>
                     <p:menuitem id="department" value="Department" icon="pi pi-eye"
                         outcome="/pages/department/DepartmentView" />
                     <p:menuitem id="team" value="Teams" icon="pi pi-fw pi-users" outcome="/pages/team/TeamView"
@@ -38,7 +43,6 @@
                     <p:menuitem id="staff" value="Staff management" icon="pi pi-fw pi-users"
                         outcome="/pages/staff/StaffView"
                         rendered="#{dashboard.loggedinUser.hasPermission('View Users') || dashboard.loggedinUser.hasPermission('Create Staff') || dashboard.loggedinUser.hasPermission('Delete Staff') || dashboard.loggedinUser.hasPermission('Edit Staff')}" />
-
                     <p:submenu id="settings" label="Settings" icon="pi pi-fw pi-cog">
                         <p:menuitem id="roles" value="Roles" icon="fa fa-wrench" outcome="/pages/roles/RolesView" />
                     </p:submenu>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/goal/GoalFormDialog.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/goal/GoalFormDialog.xhtml
@@ -1,0 +1,169 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+
+
+    <ui:define name="content">
+        <h:form id="GoalFormDialog" styleClass="card">
+            <h:panelGrid columns="1" styleClass="p-grid ui-fluid">
+                <!-- Period -->
+                <h:panelGroup styleClass="p-col-12 p-md-6">
+                    <p:outputLabel for="period" value="Period *" styleClass="field-label" />
+                    <p:selectOneMenu id="period" value="#{goalFormDialog.model.goalPeriod}"
+                                     converter="goalPeriodConverter"
+                                     required="true" filter="true" filterMatchMode="contains"
+                                     requiredMessage="Period is required.">
+                        <f:selectItem itemLabel="Select Period" itemValue="#{null}" />
+                        <f:selectItems value="#{goalFormDialog.goalPeriods}" var="p1"
+                                       itemLabel="#{p1.periodName}" itemValue="#{p1}" />
+                    </p:selectOneMenu>
+                    <p:message for="period" display="icon" />
+                </h:panelGroup>
+
+                <!-- Goal Level -->
+                <h:panelGroup styleClass="p-col-12 p-md-6">
+                    <h5>Goal Level</h5>
+                    <p:selectOneMenu id="goalLevel" value="#{goalFormDialog.model.goalLevel}"
+                                     converter="goalLevelConverter"
+                                     filter="true" filterMatchMode="contains" required="true"
+                                     styleClass="w-full">
+                        <f:selectItem itemLabel="-- Select Goal Level --" itemValue="#{null}"
+                                      noSelectionOption="true" />
+                        <f:selectItems value="#{goalFormDialog.goalLevels}" var="goalLevel"
+                                       itemLabel="#{goalLevel.displayName}" itemValue="#{goalLevel}" />
+                        <p:ajax event="change" listener="#{goalFormDialog.onGoalLevelChange}"
+                                update="goalLevelInfo dynamicFieldsContainer" />
+                    </p:selectOneMenu>
+                    <p:message for="goalLevel" display="icon" />
+                </h:panelGroup>
+
+                <!-- Goal Title -->
+                <h:panelGroup styleClass="p-col-12">
+                    <h5>Goal Title</h5>
+                    <p:inputText id="goalName" value="#{goalFormDialog.model.goalName}"
+                                 placeholder="e.g. Increase Sales Revenue by 15%"
+                                 required="true" styleClass="w-full" />
+                    <p:message for="goalName" display="icon" />
+                </h:panelGroup>
+
+                <!-- Goal Description -->
+                <h:panelGroup styleClass="p-col-12">
+                    <h5>Description</h5>
+                    <p:inputTextarea id="description" value="#{goalFormDialog.model.description}"
+                                     rows="4" placeholder="Describe the goal in detail..."
+                                     styleClass="w-full" />
+                    <p:message for="description" display="icon" />
+                </h:panelGroup>
+
+                <!-- Goal Level Info Panel -->
+                <p:outputPanel id="goalLevelInfo" styleClass="p-col-12">
+                    <p:panel rendered="#{goalFormDialog.model.goalLevel != null}"
+                             styleClass="ui-message ui-message-info">
+                        <i class="pi pi-info-circle"></i>
+                        <h:panelGroup id="goalLevelDescription">
+                            <ui:fragment rendered="#{goalFormDialog.model.goalLevel == 'ORGANISATION'}">
+                                Organisation goals are top-level goals that don't require a parent. They set the overall direction for the organization.
+                            </ui:fragment>
+                            <ui:fragment rendered="#{goalFormDialog.model.goalLevel == 'DEPARTMENT'}">
+                                Department goals must have a parent organisation goal and specify which department they belong to.
+                            </ui:fragment>
+                            <ui:fragment rendered="#{goalFormDialog.model.goalLevel == 'TEAM'}">
+                                Team goals must have a parent department goal. The department will be automatically set from the parent goal.
+                            </ui:fragment>
+                            <ui:fragment rendered="#{goalFormDialog.model.goalLevel == 'INDIVIDUAL'}">
+                                Individual goals must have a parent team goal and specify the individual owner. The department will be automatically set from the parent goal.
+                            </ui:fragment>
+                        </h:panelGroup>
+                    </p:panel>
+                </p:outputPanel>
+
+                <!-- Dynamic Fields Container -->
+                <p:outputPanel id="dynamicFieldsContainer" layout="block">
+                    <!-- Parent Goal -->
+                    <p:outputPanel id="parentGoalSection" styleClass="p-col-12 p-md-6 field-section"
+                                   rendered="#{goalFormDialog.isParentApplicable()}">
+                        <h5>Parent Goal <span class="required-asterisk">*</span></h5>
+                        <p:selectOneMenu id="parentGoalDropdown" value="#{goalFormDialog.model.parentGoal}"
+                                         converter="goalConverter" filter="true" filterMatchMode="contains"
+                                         required="true" styleClass="w-full">
+                            <f:selectItem itemLabel="-- Select Parent Goal --" itemValue="#{null}"
+                                          noSelectionOption="true" />
+                            <f:selectItems value="#{goalFormDialog.availableParentGoals}" var="goal"
+                                           itemLabel="#{goal.goalName}" itemValue="#{goal}" />
+                            <p:ajax event="change" listener="#{goalFormDialog.onParentGoalChange}"
+                                    update="departmentSection weightSection" />
+                        </p:selectOneMenu>
+                        <p:message for="parentGoalDropdown" display="icon" />
+                    </p:outputPanel>
+
+                    <!-- Weight -->
+                    <p:outputPanel id="weightSection" styleClass="p-col-12 p-md-6 field-section"
+                                   rendered="#{goalFormDialog.isWeightApplicable()}">
+                        <h5>Weight (%) <span class="required-asterisk">*</span></h5>
+                        <p:inputNumber id="weight" value="#{goalFormDialog.model.weight}"
+                                       min="0" max="100" required="true" decimalPlaces="2"
+                                       styleClass="w-full">
+                            <f:validateDoubleRange minimum="0" maximum="100" />
+                        </p:inputNumber>
+                        <p:message for="weight" display="icon" />
+                        <small class="field-hint">Contribution to parent goal (0-100%)</small>
+                    </p:outputPanel>
+
+                    <!-- Department -->
+                    <p:outputPanel id="departmentSection" styleClass="p-col-12 p-md-6 field-section"
+                                   rendered="#{goalFormDialog.isDepartmentApplicable()}">
+                        <h5>Department
+                            <ui:fragment rendered="#{goalFormDialog.departmentEditable}">
+                                <span class="required-asterisk">*</span>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{not goalFormDialog.departmentEditable}">
+                                <span class="auto-set-label">(Auto-set from parent)</span>
+                            </ui:fragment>
+                        </h5>
+                        <p:selectOneMenu id="department" value="#{goalFormDialog.model.department}"
+                                         converter="departmentConverter" filter="true" filterMatchMode="contains"
+                                         disabled="#{not goalFormDialog.departmentEditable}"
+                                         required="#{goalFormDialog.departmentEditable}" styleClass="w-full">
+                            <f:selectItem itemLabel="-- Select Department --" itemValue="#{null}"
+                                          noSelectionOption="true" />
+                            <f:selectItems value="#{goalFormDialog.availableDepartments}" var="dept"
+                                           itemLabel="#{dept.name}" itemValue="#{dept}" />
+                        </p:selectOneMenu>
+                        <p:message for="department" display="icon" />
+                        <ui:fragment rendered="#{not goalFormDialog.departmentEditable}">
+                            <small class="field-hint">Department is automatically set from the parent goal</small>
+                        </ui:fragment>
+                    </p:outputPanel>
+
+                    <!-- Owner -->
+                    <p:outputPanel id="ownerSection" styleClass="p-col-12 p-md-6 field-section"
+                                   rendered="#{goalFormDialog.isOwnerApplicable()}">
+                        <h5>Owner <span class="required-asterisk">*</span></h5>
+                        <p:selectOneMenu id="owner" value="#{goalFormDialog.model.owner}"
+                                         converter="staffConverter" filter="true" filterMatchMode="contains"
+                                         required="true" styleClass="w-full">
+                            <f:selectItem itemLabel="-- Select Owner --" itemValue="#{null}"
+                                          noSelectionOption="true" />
+                            <f:selectItems value="#{goalFormDialog.availableStaff}" var="staff"
+                                           itemLabel="#{staff.fullName}" itemValue="#{staff}" />
+                        </p:selectOneMenu>
+                        <p:message for="owner" display="icon" />
+                        <small class="field-hint">Individual responsible for this goal</small>
+                    </p:outputPanel>
+                </p:outputPanel>
+
+                <!-- Form Buttons -->
+                <h:panelGroup styleClass="p-col-12 p-d-flex p-jc-end p-mt-4">
+                    <p:commandButton value="Cancel" immediate="true" process="@this"
+                                     actionListener="#{goalFormDialog.hide}"
+                                     styleClass="ui-button-outlined ui-button-danger p-mr-2" />
+                    <p:commandButton value="Save" process="@form"
+                                     actionListener="#{goalFormDialog.save}" update="@form" />
+                </h:panelGroup>
+            </h:panelGrid>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/goal/GoalView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/goal/GoalView.xhtml
@@ -1,0 +1,343 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+    <ui:define name="title">Goal Management</ui:define>
+    <ui:define name="viewname">Goals</ui:define>
+
+
+    <ui:define name="content">
+        <h:form id="goalViewForm" enctype="multipart/form-data">
+            <p:messages id="globalMessages" autoUpdate="true" closable="true" />
+
+            <!-- Dashboard Metrics Cards -->
+            <div class="grid mb-4">
+                <div class="col-12 md:col-3">
+                    <div class="metric-card">
+                        <div class="text-xl font-bold mb-2">Total Goals</div>
+                        <div class="text-3xl font-bold">#{not empty goalView.dashboardMetrics ?
+                                goalView.dashboardMetrics.totalGoals : 0}</div>
+                    </div>
+                </div>
+                <div class="col-12 md:col-3">
+                    <div class="metric-card">
+                        <div class="text-xl font-bold mb-2">Active Goals</div>
+                        <div class="text-3xl font-bold">#{not empty goalView.dashboardMetrics ?
+                                goalView.dashboardMetrics.activeGoals : 0}</div>
+                    </div>
+                </div>
+                <div class="col-12 md:col-3">
+                    <div class="metric-card">
+                        <div class="text-xl font-bold mb-2">Completed Goals</div>
+                        <div class="text-3xl font-bold">#{not empty goalView.dashboardMetrics ?
+                                goalView.dashboardMetrics.completedGoals : 0}</div>
+                    </div>
+                </div>
+                <div class="col-12 md:col-3">
+                    <div class="metric-card">
+                        <div class="text-xl font-bold mb-2">Overdue Goals</div>
+                        <div class="text-3xl font-bold">#{not empty goalView.dashboardMetrics ?
+                                goalView.dashboardMetrics.overdueGoals : 0}</div>
+                    </div>
+                </div>
+            </div>
+
+            <p:tabView id="goalTabs" activeIndex="#{goalView.activeTabIndex}">
+                <p:tab id="myGoalsTab" title="My Goals">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="card-title mb-0">
+                                <i class="pi pi-list"></i> My Goals
+                            </h5>
+                            <p:commandButton id="createMyGoalBtn" value="Create New Goal" icon="pi pi-plus"
+                                             actionListener="#{goalFormDialog.show}"
+                                             update=":goalViewForm:globalMessages"
+                                             styleClass="p-button-success">
+                                <f:setPropertyActionListener value="#{null}" target="#{goalFormDialog.model}" />
+                                <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                        update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                            </p:commandButton>
+                        </div>
+                        <div class="card-body">
+                            <p:dataTable id="myGoalsTable" value="#{goalView.myGoals}" var="goal"
+                                         styleClass="w-full" emptyMessage="No individual goals found"
+                                         paginator="true" rows="10" paginatorPosition="bottom"
+                                         paginatorTemplate="{FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="5,10,20,50">
+                                <p:column headerText="Goal Name" sortBy="#{goal.goalName}"
+                                          filterBy="#{goal.goalName}" filterMatchMode="contains">
+                                    <h:outputText value="#{goal.goalName}" />
+                                </p:column>
+                                <p:column headerText="Department" sortBy="#{goal.department.name}">
+                                    <h:outputText value="#{not empty goal.department ? goal.department.name : ''}" />
+                                </p:column>
+                                <p:column headerText="Weight" sortBy="#{goal.weight}">
+                                    <h:outputText value="#{goal.weight}%" />
+                                </p:column>
+                                <p:column headerText="Parent Goal" sortBy="#{goal.parentGoal.goalName}">
+                                    <h:outputText value="#{not empty goal.parentGoal ? goal.parentGoal.goalName : ''}" />
+                                </p:column>
+                                <p:column headerText="Progress" sortBy="#{goal.progress}">
+                                    <div class="flex align-items-center">
+                                        <p:progressBar value="#{goal.progress}" styleClass="flex-1 mr-2" />
+                                        <span class="text-sm">#{goal.progress}%</span>
+                                    </div>
+                                </p:column>
+                                <p:column headerText="End Date" sortBy="#{goal.endDate}">
+                                    <h:outputText value="#{goal.endDate}">
+                                        <f:convertDateTime pattern="MMM dd, yyyy" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Status" sortBy="#{goal.goalStatus}">
+                                    <h:outputText value="#{goal.goalStatus}"
+                                                  styleClass="ui-tag #{goal.goalStatus == 'Completed' ? 'status-completed' : goal.goalStatus == 'Overdue' ? 'status-overdue' : 'status-active'}" />
+                                </p:column>
+                                <p:column headerText="Actions" styleClass="text-center">
+                                    <div class="flex justify-content-center">
+                                        <p:commandButton id="editMyGoal_#{goal.id}" icon="pi pi-pencil"
+                                                         styleClass="p-button-text p-button-sm mr-1"
+                                                         actionListener="#{goalFormDialog.show}">
+                                            <f:setPropertyActionListener value="#{goal}"
+                                                                         target="#{goalFormDialog.model}" />
+                                            <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                                    update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                                        </p:commandButton>
+                                        <p:commandButton id="deleteMyGoal_#{goal.id}" icon="pi pi-trash"
+                                                         styleClass="p-button-text p-button-danger p-button-sm"
+                                                         actionListener="#{goalView.deleteSelectedGoal(goal)}"
+                                                         update=":goalViewForm:goalTabs :goalViewForm:globalMessages">
+                                            <p:confirm header="Confirmation"
+                                                       message="You are about to delete goal '#{goal.goalName}'. Are you sure?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </div>
+                                </p:column>
+                            </p:dataTable>
+                        </div>
+                    </div>
+                </p:tab>
+
+                <p:tab id="orgGoalsTab" title="Organisation Goals">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="card-title mb-0">
+                                <i class="pi pi-list"></i> Organisation Goals
+                            </h5>
+                            <p:commandButton id="createOrgGoalBtn" value="Create New Goal" icon="pi pi-plus"
+                                             actionListener="#{goalFormDialog.show}"
+                                             update=":goalViewForm:globalMessages"
+                                             styleClass="p-button-success">
+                                <f:setPropertyActionListener value="#{null}" target="#{goalFormDialog.model}" />
+                                <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                        update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                            </p:commandButton>
+                        </div>
+                        <div class="card-body">
+                            <p:dataTable id="orgGoalsTable" value="#{goalView.organisationGoals}" var="goal"
+                                         styleClass="w-full" emptyMessage="No organisation goals found"
+                                         paginator="true" rows="10" paginatorPosition="bottom"
+                                         paginatorTemplate="{FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="5,10,20,50">
+                                <p:column headerText="Goal Name" sortBy="#{goal.goalName}"
+                                          filterBy="#{goal.goalName}" filterMatchMode="contains">
+                                    <h:outputText value="#{goal.goalName}" />
+                                </p:column>
+                                <p:column headerText="Progress" sortBy="#{goal.progress}">
+                                    <div class="flex align-items-center">
+                                        <p:progressBar value="#{goal.progress}" styleClass="flex-1 mr-2" />
+                                        <span class="text-sm">#{goal.progress}%</span>
+                                    </div>
+                                </p:column>
+                                <p:column headerText="End Date" sortBy="#{goal.endDate}">
+                                    <h:outputText value="#{goal.endDate}">
+                                        <f:convertDateTime pattern="MMM dd, yyyy" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Status" sortBy="#{goal.goalStatus}">
+                                    <h:outputText value="#{goal.goalStatus}"
+                                                  styleClass="ui-tag #{goal.goalStatus == 'Completed' ? 'status-completed' : goal.goalStatus == 'Overdue' ? 'status-overdue' : 'status-active'}" />
+                                </p:column>
+                                <p:column headerText="Actions" styleClass="text-center">
+                                    <div class="flex justify-content-center">
+                                        <p:commandButton id="editOrgGoal_#{goal.id}" icon="pi pi-pencil"
+                                                         styleClass="p-button-text p-button-sm mr-1"
+                                                         actionListener="#{goalFormDialog.show}">
+                                            <f:setPropertyActionListener value="#{goal}"
+                                                                         target="#{goalFormDialog.model}" />
+                                            <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                                    update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                                        </p:commandButton>
+                                        <p:commandButton id="deleteOrgGoal_#{goal.id}" icon="pi pi-trash"
+                                                         styleClass="p-button-text p-button-danger p-button-sm"
+                                                         actionListener="#{goalView.deleteSelectedGoal(goal)}"
+                                                         update=":goalViewForm:goalTabs :goalViewForm:globalMessages">
+                                            <p:confirm header="Confirmation"
+                                                       message="You are about to delete goal '#{goal.goalName}'. Are you sure?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </div>
+                                </p:column>
+                            </p:dataTable>
+                        </div>
+                    </div>
+                </p:tab>
+
+                <p:tab id="deptGoalsTab" title="Department Goals">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="card-title mb-0">
+                                <i class="pi pi-list"></i> Department Goals
+                            </h5>
+                            <p:commandButton id="createDeptGoalBtn" value="Create New Goal" icon="pi pi-plus"
+                                             actionListener="#{goalFormDialog.show}"
+                                             update=":goalViewForm:globalMessages"
+                                             styleClass="p-button-success">
+                                <f:setPropertyActionListener value="#{null}" target="#{goalFormDialog.model}" />
+                                <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                        update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                            </p:commandButton>
+                        </div>
+                        <div class="card-body">
+                            <p:dataTable id="deptGoalsTable" value="#{goalView.departmentGoals}" var="goal"
+                                         styleClass="w-full" emptyMessage="No department goals found"
+                                         paginator="true" rows="10" paginatorPosition="bottom"
+                                         paginatorTemplate="{FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="5,10,20,50">
+                                <p:column headerText="Goal Name" sortBy="#{goal.goalName}"
+                                          filterBy="#{goal.goalName}" filterMatchMode="contains">
+                                    <h:outputText value="#{goal.goalName}" />
+                                </p:column>
+                                <p:column headerText="Department" sortBy="#{goal.department.name}">
+                                    <h:outputText value="#{not empty goal.department ? goal.department.name : ''}" />
+                                </p:column>
+                                <p:column headerText="Parent Goal" sortBy="#{goal.parentGoal.goalName}">
+                                    <h:outputText value="#{not empty goal.parentGoal ? goal.parentGoal.goalName : ''}" />
+                                </p:column>
+                                <p:column headerText="Progress" sortBy="#{goal.progress}">
+                                    <div class="flex align-items-center">
+                                        <p:progressBar value="#{goal.progress}" styleClass="flex-1 mr-2" />
+                                        <span class="text-sm">#{goal.progress}%</span>
+                                    </div>
+                                </p:column>
+                                <p:column headerText="End Date" sortBy="#{goal.endDate}">
+                                    <h:outputText value="#{goal.endDate}">
+                                        <f:convertDateTime pattern="MMM dd, yyyy" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Status" sortBy="#{goal.goalStatus}">
+                                    <h:outputText value="#{goal.goalStatus}"
+                                                  styleClass="ui-tag #{goal.goalStatus == 'Completed' ? 'status-completed' : goal.goalStatus == 'Overdue' ? 'status-overdue' : 'status-active'}" />
+                                </p:column>
+                                <p:column headerText="Actions" styleClass="text-center">
+                                    <div class="flex justify-content-center">
+                                        <p:commandButton id="editDeptGoal_#{goal.id}" icon="pi pi-pencil"
+                                                         styleClass="p-button-text p-button-sm mr-1"
+                                                         actionListener="#{goalFormDialog.show}">
+                                            <f:setPropertyActionListener value="#{goal}"
+                                                                         target="#{goalFormDialog.model}" />
+                                            <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                                    update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                                        </p:commandButton>
+                                        <p:commandButton id="deleteDeptGoal_#{goal.id}" icon="pi pi-trash"
+                                                         styleClass="p-button-text p-button-danger p-button-sm"
+                                                         actionListener="#{goalView.deleteSelectedGoal(goal)}"
+                                                         update=":goalViewForm:goalTabs :goalViewForm:globalMessages">
+                                            <p:confirm header="Confirmation"
+                                                       message="You are about to delete goal '#{goal.goalName}'. Are you sure?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </div>
+                                </p:column>
+                            </p:dataTable>
+                        </div>
+                    </div>
+                </p:tab>
+
+                <p:tab id="teamGoalsTab" title="Team Goals">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="card-title mb-0">
+                                <i class="pi pi-list"></i> Team Goals
+                            </h5>
+                            <p:commandButton id="createTeamGoalBtn" value="Create New Goal" icon="pi pi-plus"
+                                             actionListener="#{goalFormDialog.show}"
+                                             update=":goalViewForm:globalMessages"
+                                             styleClass="p-button-success">
+                                <f:setPropertyActionListener value="#{null}" target="#{goalFormDialog.model}" />
+                                <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                        update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                            </p:commandButton>
+                        </div>
+                        <div class="card-body">
+                            <p:dataTable id="teamGoalsTable" value="#{goalView.teamGoals}" var="goal"
+                                         styleClass="w-full" emptyMessage="No team goals found"
+                                         paginator="true" rows="10" paginatorPosition="bottom"
+                                         paginatorTemplate="{FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="5,10,20,50">
+                                <p:column headerText="Goal Name" sortBy="#{goal.goalName}"
+                                          filterBy="#{goal.goalName}" filterMatchMode="contains">
+                                    <h:outputText value="#{goal.goalName}" />
+                                </p:column>
+                                <p:column headerText="Department" sortBy="#{goal.department.name}">
+                                    <h:outputText value="#{not empty goal.department ? goal.department.name : ''}" />
+                                </p:column>
+                                <p:column headerText="Weight" sortBy="#{goal.weight}">
+                                    <h:outputText value="#{goal.weight}%" />
+                                </p:column>
+                                <p:column headerText="Parent Goal" sortBy="#{goal.parentGoal.goalName}">
+                                    <h:outputText value="#{not empty goal.parentGoal ? goal.parentGoal.goalName : ''}" />
+                                </p:column>
+                                <p:column headerText="Progress" sortBy="#{goal.progress}">
+                                    <div class="flex align-items-center">
+                                        <p:progressBar value="#{goal.progress}" styleClass="flex-1 mr-2" />
+                                        <span class="text-sm">#{goal.progress}%</span>
+                                    </div>
+                                </p:column>
+                                <p:column headerText="End Date" sortBy="#{goal.endDate}">
+                                    <h:outputText value="#{goal.endDate}">
+                                        <f:convertDateTime pattern="MMM dd, yyyy" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Status" sortBy="#{goal.goalStatus}">
+                                    <h:outputText value="#{goal.goalStatus}"
+                                                  styleClass="ui-tag #{goal.goalStatus == 'Completed' ? 'status-completed' : goal.goalStatus == 'Overdue' ? 'status-overdue' : 'status-active'}" />
+                                </p:column>
+                                <p:column headerText="Actions" styleClass="text-center">
+                                    <div class="flex justify-content-center">
+                                        <p:commandButton id="editTeamGoal_#{goal.id}" icon="pi pi-pencil"
+                                                         styleClass="p-button-text p-button-sm mr-1"
+                                                         actionListener="#{goalFormDialog.show}">
+                                            <f:setPropertyActionListener value="#{goal}"
+                                                                         target="#{goalFormDialog.model}" />
+                                            <p:ajax event="dialogReturn" listener="#{goalView.reloadFilterReset}"
+                                                    update=":goalViewForm:goalTabs :goalViewForm:globalMessages" />
+                                        </p:commandButton>
+                                        <p:commandButton id="deleteTeamGoal_#{goal.id}" icon="pi pi-trash"
+                                                         styleClass="p-button-text p-button-danger p-button-sm"
+                                                         actionListener="#{goalView.deleteSelectedGoal(goal)}"
+                                                         update=":goalViewForm:goalTabs :goalViewForm:globalMessages">
+                                            <p:confirm header="Confirmation"
+                                                       message="You are about to delete goal '#{goal.goalName}'. Are you sure?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </div>
+                                </p:column>
+                            </p:dataTable>
+                        </div>
+                    </div>
+                </p:tab>
+            </p:tabView>
+
+            <p:confirmDialog global="true" id="globalConfirmDialog">
+                <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="pi pi-check" />
+                <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" />
+            </p:confirmDialog>
+        </h:form>
+        <ui:include src="/pages/goal/GoalFormDialog.xhtml" />
+    </ui:define>
+
+
+</ui:composition>


### PR DESCRIPTION
Introduces backend and frontend support for managing goals and goal periods, including new JSF managed beans, service integration, and UI pages for creating, viewing, and deleting goals and goal periods. Updates the sidebar navigation to include a 'Goals and Objectives' section. Adds entity mappings for Goal and GoalPeriod in Hibernate configuration. Also adds a getFullName() helper to the Staff model.

#### Description
=> Full details of the tasks in the PR
#### Type of change
=> Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
=> Please select the relevant option
- [ ] Unit
- [ ] Integration
- [ ] End-to-end
#### How can this be Tested?
=> Include the steps needed to test this PR
#### Any background context you want to add
